### PR TITLE
chore(cargo): Update homepage and repository URLs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ authors = [
     "Jack Grigg <jack@electriccoin.co>",
     "Kris Nuttycombe <kris@electriccoin.co>"
 ]
-homepage = "https://github.com/zcash/librustzcash"
-repository = "https://github.com/zcash/librustzcash"
+homepage = "https://github.com/zcash/zcash_note_encryption"
+repository = "https://github.com/zcash/zcash_note_encryption"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## Motivation

The links at https://crates.io/crates/zcash_note_encryption point to lrz, which is not the repo for this crate.