### PR TITLE
Add `ShieldedOutput::cmstar`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `ShieldedOutput` has added method `cmstar`, which exposes the
+  `ExtractedCommitment` of the shielded output directly, in addition to the
+  byte encoding exposed by `ShieldedOutput::cmstar_bytes`. This is useful for
+  further generalizing scanning code.
 
 ## [0.4.1] - 2024-12-06
 ### Added
@@ -13,7 +18,7 @@ and this library adheres to Rust's notion of
 
 ## [0.4.0] - 2023-06-06
 ### Changed
-- The `esk` and `ephemeral_key` arguments have been removed from 
+- The `esk` and `ephemeral_key` arguments have been removed from
   `Domain::parse_note_plaintext_without_memo_ovk`. It is therefore no longer
   necessary (or possible) to ensure that `ephemeral_key` is derived from `esk`
   and the diversifier within the note plaintext. We have analyzed the safety of
@@ -25,7 +30,7 @@ and this library adheres to Rust's notion of
 ## [0.3.0] - 2023-03-22
 ### Changed
 - The `recipient` parameter has been removed from `Domain::note_plaintext_bytes`.
-- The `recipient` parameter has been removed from `NoteEncryption::new`. Since 
+- The `recipient` parameter has been removed from `NoteEncryption::new`. Since
   the `Domain::Note` type is now expected to contain information about the
   recipient of the note, there is no longer any need to pass this information
   in via the encryption context.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- A blanket `impl<D, O, const CIPHERTEXT_SIZE: usize> ShieldedOutput<D, CIPHERTEXT_SIZE> for &O`
+    where `D: Domain, O: ShieldedOutput<D, CIPHERTEXT_SIZE>`
+
 ### Changed
 - `ShieldedOutput` has added method `cmstar`, which exposes the
   `ExtractedCommitment` of the shielded output directly, in addition to the

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Orchard protocols. It provides reusable methods that implement common note encry
 and trial decryption logic, and enforce protocol-agnostic verification requirements.
 
 Protocol-specific logic is handled via the `Domain` trait. Implementations of this
-trait are provided in the [`zcash_primitives`] (for Sapling) and [`orchard`] crates;
-users with their own existing types can similarly implement the trait themselves.
+trait are provided in the [`sapling-crypto`] and [`orchard`] crates; users with their
+own existing types can similarly implement the trait themselves.
 
 [in-band secret distribution scheme]: https://zips.z.cash/protocol/protocol.pdf#saplingandorchardinband
-[`zcash_primitives`]: https://crates.io/crates/zcash_primitives
+[`sapling-crypto`]: https://crates.io/crates/sapling-crypto
 [`orchard`]: https://crates.io/crates/orchard
 
 ## License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,11 +5,11 @@
 //! and trial decryption logic, and enforce protocol-agnostic verification requirements.
 //!
 //! Protocol-specific logic is handled via the [`Domain`] trait. Implementations of this
-//! trait are provided in the [`zcash_primitives`] (for Sapling) and [`orchard`] crates;
-//! users with their own existing types can similarly implement the trait themselves.
+//! trait are provided in the [`sapling-crypto`] and [`orchard`] crates; users with their
+//! own existing types can similarly implement the trait themselves.
 //!
 //! [in-band secret distribution scheme]: https://zips.z.cash/protocol/protocol.pdf#saplingandorchardinband
-//! [`zcash_primitives`]: https://crates.io/crates/zcash_primitives
+//! [`sapling-crypto`]: https://crates.io/crates/sapling-crypto
 //! [`orchard`]: https://crates.io/crates/orchard
 
 #![no_std]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,6 +346,24 @@ pub trait ShieldedOutput<D: Domain, const CIPHERTEXT_SIZE: usize> {
     fn enc_ciphertext(&self) -> &[u8; CIPHERTEXT_SIZE];
 }
 
+impl<D, O, const CIPHERTEXT_SIZE: usize> ShieldedOutput<D, CIPHERTEXT_SIZE> for &O
+where
+    D: Domain,
+    O: ShieldedOutput<D, CIPHERTEXT_SIZE>,
+{
+    fn ephemeral_key(&self) -> EphemeralKeyBytes {
+        (*self).ephemeral_key()
+    }
+
+    fn cmstar(&self) -> &<D as Domain>::ExtractedCommitment {
+        (*self).cmstar()
+    }
+
+    fn enc_ciphertext(&self) -> &[u8; CIPHERTEXT_SIZE] {
+        (*self).enc_ciphertext()
+    }
+}
+
 /// A struct containing context required for encrypting Sapling and Orchard notes.
 ///
 /// This struct provides a safe API for encrypting Sapling and Orchard notes. In particular, it

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,8 +334,13 @@ pub trait ShieldedOutput<D: Domain, const CIPHERTEXT_SIZE: usize> {
     /// Exposes the `ephemeral_key` field of the output.
     fn ephemeral_key(&self) -> EphemeralKeyBytes;
 
-    /// Exposes the `cmu_bytes` or `cmx_bytes` field of the output.
-    fn cmstar_bytes(&self) -> D::ExtractedCommitmentBytes;
+    /// Exposes the `cmu` or `cmx` field of the output.
+    fn cmstar(&self) -> &D::ExtractedCommitment;
+
+    /// Exposes the `cmu_bytes` or `cmx_bytes` representation of the output.
+    fn cmstar_bytes(&self) -> D::ExtractedCommitmentBytes {
+        D::ExtractedCommitmentBytes::from(self.cmstar())
+    }
 
     /// Exposes the note ciphertext of the output.
     fn enc_ciphertext(&self) -> &[u8; CIPHERTEXT_SIZE];


### PR DESCRIPTION
It is useful to be able to obtain the parsed cmstar value in scanning, where this allows the `Domain::ExtractedNoteCommitment` type to inform the creation of wallet-specific note commitment tree leaf types.